### PR TITLE
fix(workflow): windows CUDA build workflow for multipule compute capability

### DIFF
--- a/.github/workflows/build-extended-artifacts.yml
+++ b/.github/workflows/build-extended-artifacts.yml
@@ -114,6 +114,8 @@ jobs:
         exclude:
           - cuda: '12.4.1'
             compute_cap: 120
+          - cuda: '13.0.2'
+            compute_cap: 70
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates the Windows CUDA binary build workflow to support multiple compute capabilities (70, 75, etc.) using a matrix strategy, similar to the existed Linux Docker container build workflow. 

Fixes #37
