### PR TITLE
feat: Add documentation for the model-config parameter

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -11,38 +11,39 @@ cargo run -p deepseek-ocr-cli --release -- \
 
 ### Arguments
 
-| Flag | Default | Description |
-| --- | --- | --- |
-| `--prompt` | – | Inline text with `<image>` markers. |
-| `--prompt-file` | – | UTF-8 file containing the prompt; overrides `--prompt`. |
-| `--template` | `plain` | Conversation template (`plain`, `deepseek`, `deepseekv2`, `alignment`). |
-| `--image PATH` | – | Image path for each `<image>` token, specified in order. Repeat the flag for multiple images. |
-| `--tokenizer PATH` | assets default | Override tokenizer location; downloaded automatically when omitted. |
-| `--weights PATH` | auto-detected | Use custom model weights instead of the default safetensor. |
-| `--device` | `cpu` | Execution backend: `cpu`, `metal`, or `cuda` (alpha). |
-| `--dtype` | backend default | Override numeric precision (`f32`, `f16`, `bf16`, …). |
-| `--base-size` | `1024` | Global view resolution supplied to the vision stack. |
-| `--image-size` | `640` | Local crop resolution when dynamic tiling is enabled. |
-| `--crop-mode` | `true` | Toggle dynamic crop sampling (`false` to disable). |
-| `--max-new-tokens` | `512` | Maximum number of tokens generated during decoding. |
-| `--no-cache` | `false` | Disable the decoder KV-cache. Helpful for debugging only. |
-| `--do-sample` | `false` | Enable sampling (requires `--temperature > 0`). |
-| `--temperature` | `0.0` | Softmax temperature used when sampling is enabled. |
-| `--top-p` | `1.0` | Nucleus sampling mass; ignored unless sampling. |
-| `--top-k` | – | Top-k cutoff during sampling. |
-| `--repetition-penalty` | `1.0` | Penalise previously generated tokens (>1 discourages repeats). |
-| `--no-repeat-ngram-size` | `20` | N-gram blocking window applied to every decode step. |
-| `--seed` | – | RNG seed for reproducible sampling runs. |
+| Flag                     | Default         | Description                                                                                                                                                 |
+|--------------------------|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--prompt`               | –               | Inline text with `<image>` markers.                                                                                                                         |
+| `--prompt-file`          | –               | UTF-8 file containing the prompt; overrides `--prompt`.                                                                                                     |
+| `--template`             | `plain`         | Conversation template (`plain`, `deepseek`, `deepseekv2`, `alignment`).                                                                                     |
+| `--image PATH`           | –               | Image path for each `<image>` token, specified in order. Repeat the flag for multiple images.                                                               |
+| `--tokenizer PATH`       | assets default  | Override tokenizer location; downloaded automatically when omitted.                                                                                         |
+| `--weights PATH`         | auto-detected   | Use custom model weights instead of the default safetensor.                                                                                                 |
+| `--model-config PATH`    | auto-detected   | Specify the model architecture configuration file, overriding the default config.json. In offline environments, point to a pre-downloaded config file path. |
+| `--device`               | `cpu`           | Execution backend: `cpu`, `metal`, or `cuda` (alpha).                                                                                                       |
+| `--dtype`                | backend default | Override numeric precision (`f32`, `f16`, `bf16`, …).                                                                                                       |
+| `--base-size`            | `1024`          | Global view resolution supplied to the vision stack.                                                                                                        |
+| `--image-size`           | `640`           | Local crop resolution when dynamic tiling is enabled.                                                                                                       |
+| `--crop-mode`            | `true`          | Toggle dynamic crop sampling (`false` to disable).                                                                                                          |
+| `--max-new-tokens`       | `512`           | Maximum number of tokens generated during decoding.                                                                                                         |
+| `--no-cache`             | `false`         | Disable the decoder KV-cache. Helpful for debugging only.                                                                                                   |
+| `--do-sample`            | `false`         | Enable sampling (requires `--temperature > 0`).                                                                                                             |
+| `--temperature`          | `0.0`           | Softmax temperature used when sampling is enabled.                                                                                                          |
+| `--top-p`                | `1.0`           | Nucleus sampling mass; ignored unless sampling.                                                                                                             |
+| `--top-k`                | –               | Top-k cutoff during sampling.                                                                                                                               |
+| `--repetition-penalty`   | `1.0`           | Penalise previously generated tokens (>1 discourages repeats).                                                                                              |
+| `--no-repeat-ngram-size` | `20`            | N-gram blocking window applied to every decode step.                                                                                                        |
+| `--seed`                 | –               | RNG seed for reproducible sampling runs.                                                                                                                    |
 
 > **Heads-up:** If the final markdown appears truncated, increase `--max-new-tokens`. The model stops once it has emitted the configured number of tokens even if the prompt is unfinished.
 
 ### Configuration & Overrides
 
-| Platform | Config path | Weights cache path |
-| --- | --- | --- |
-| Linux | `~/.config/deepseek-ocr/config.toml` | `~/.cache/deepseek-ocr/models/<id>/model.safetensors` |
-| macOS | `~/Library/Application Support/deepseek-ocr/config.toml` | `~/Library/Caches/deepseek-ocr/models/<id>/model.safetensors` |
-| Windows | `%APPDATA%\deepseek-ocr\config.toml` | `%LOCALAPPDATA%\deepseek-ocr\models\<id>\model.safetensors` |
+| Platform | Config path                                              | Weights cache path                                            |
+|----------|----------------------------------------------------------|---------------------------------------------------------------|
+| Linux    | `~/.config/deepseek-ocr/config.toml`                     | `~/.cache/deepseek-ocr/models/<id>/model.safetensors`         |
+| macOS    | `~/Library/Application Support/deepseek-ocr/config.toml` | `~/Library/Caches/deepseek-ocr/models/<id>/model.safetensors` |
+| Windows  | `%APPDATA%\deepseek-ocr\config.toml`                     | `%LOCALAPPDATA%\deepseek-ocr\models\<id>\model.safetensors`   |
 
 - Pass `--config /path/to/config.toml` to read or bootstrap an alternate file (created with defaults if missing).
 - Runtime values resolve in this order: CLI flags → values in `config.toml` → baked-in defaults. Asset paths behave the same way: explicit flags beat config entries which beat the cache locations listed above.

--- a/crates/cli/README_CN.md
+++ b/crates/cli/README_CN.md
@@ -11,38 +11,39 @@ cargo run -p deepseek-ocr-cli --release -- \
 
 ## 参数说明
 
-| 参数 | 默认值 | 说明 |
-| --- | --- | --- |
-| `--prompt` | – | 内联文本提示，使用 `<image>` 标记图片位置。 |
-| `--prompt-file` | – | 含提示词的 UTF-8 文件；提供后会覆盖 `--prompt`。 |
-| `--template` | `plain` | 会话模板，可选 `plain`、`deepseek`、`deepseekv2`、`alignment`。 |
-| `--image PATH` | – | 与 `<image>` 匹配的图片路径，按出现顺序重复传入该参数。 |
-| `--tokenizer PATH` | 资产默认路径 | 指定自定义分词器路径；默认自动下载并缓存。 |
-| `--weights PATH` | 自动探测 | 指定模型权重文件，覆盖默认的 safetensor。 |
-| `--device` | `cpu` | 执行后端：`cpu`、`metal` 或 `cuda`（测试阶段）。 |
-| `--dtype` | 取决于后端 | 数值精度覆盖选项，如 `f32`、`f16`、`bf16` 等。 |
-| `--base-size` | `1024` | 传入视觉模块的全局视图分辨率。 |
-| `--image-size` | `640` | 动态裁剪启用时的局部分辨率。 |
-| `--crop-mode` | `true` | 是否启用动态裁剪（传 `false` 可关闭）。 |
-| `--max-new-tokens` | `512` | 解码阶段允许输出的最大 token 数。 |
-| `--no-cache` | `false` | 禁用解码 KV 缓存，仅在调试时使用。 |
-| `--do-sample` | `false` | 是否启用采样（需搭配 `--temperature > 0`）。 |
-| `--temperature` | `0.0` | 采样温度，越大越随机。 |
-| `--top-p` | `1.0` | 核心采样累计概率，采样时有效。 |
-| `--top-k` | – | Top-k 截断，配合采样使用。 |
-| `--repetition-penalty` | `1.0` | 重复惩罚系数（>1 会降低重复概率）。 |
-| `--no-repeat-ngram-size` | `20` | n-gram 阻断窗口，生成时始终生效。 |
-| `--seed` | – | 随机种子，便于复现采样结果。 |
+| 参数                       | 默认值     | 说明                                                   |
+|--------------------------|---------|------------------------------------------------------|
+| `--prompt`               | –       | 内联文本提示，使用 `<image>` 标记图片位置。                          |
+| `--prompt-file`          | –       | 含提示词的 UTF-8 文件；提供后会覆盖 `--prompt`。                    |
+| `--template`             | `plain` | 会话模板，可选 `plain`、`deepseek`、`deepseekv2`、`alignment`。 |
+| `--image PATH`           | –       | 与 `<image>` 匹配的图片路径，按出现顺序重复传入该参数。                    |
+| `--tokenizer PATH`       | 资产默认路径  | 指定自定义分词器路径；默认自动下载并缓存。                                |
+| `--weights PATH`         | 自动探测    | 指定模型权重文件，覆盖默认的 safetensor。                           |
+| `--model-config PATH`    | 自动探测    | 指定模型架构配置文件，覆盖默认的 config.json。离线环境可配置下载好的配置路径         |
+| `--device`               | `cpu`   | 执行后端：`cpu`、`metal` 或 `cuda`（测试阶段）。                   |
+| `--dtype`                | 取决于后端   | 数值精度覆盖选项，如 `f32`、`f16`、`bf16` 等。                     |
+| `--base-size`            | `1024`  | 传入视觉模块的全局视图分辨率。                                      |
+| `--image-size`           | `640`   | 动态裁剪启用时的局部分辨率。                                       |
+| `--crop-mode`            | `true`  | 是否启用动态裁剪（传 `false` 可关闭）。                             |
+| `--max-new-tokens`       | `512`   | 解码阶段允许输出的最大 token 数。                                 |
+| `--no-cache`             | `false` | 禁用解码 KV 缓存，仅在调试时使用。                                  |
+| `--do-sample`            | `false` | 是否启用采样（需搭配 `--temperature > 0`）。                     |
+| `--temperature`          | `0.0`   | 采样温度，越大越随机。                                          |
+| `--top-p`                | `1.0`   | 核心采样累计概率，采样时有效。                                      |
+| `--top-k`                | –       | Top-k 截断，配合采样使用。                                     |
+| `--repetition-penalty`   | `1.0`   | 重复惩罚系数（>1 会降低重复概率）。                                  |
+| `--no-repeat-ngram-size` | `20`    | n-gram 阻断窗口，生成时始终生效。                                 |
+| `--seed`                 | –       | 随机种子，便于复现采样结果。                                       |
 
 > **重要提醒：** 如果生成的 Markdown 被提前截断，请调大 `--max-new-tokens`。模型在达到该上限后会立刻停止，即便尚未完成回答。
 
 ### 配置与覆盖
 
-| 平台 | 配置文件路径 | 权重缓存路径 |
-| --- | --- | --- |
-| Linux | `~/.config/deepseek-ocr/config.toml` | `~/.cache/deepseek-ocr/models/<id>/model.safetensors` |
-| macOS | `~/Library/Application Support/deepseek-ocr/config.toml` | `~/Library/Caches/deepseek-ocr/models/<id>/model.safetensors` |
-| Windows | `%APPDATA%\deepseek-ocr\config.toml` | `%LOCALAPPDATA%\deepseek-ocr\models\<id>\model.safetensors` |
+| 平台      | 配置文件路径                                                   | 权重缓存路径                                                        |
+|---------|----------------------------------------------------------|---------------------------------------------------------------|
+| Linux   | `~/.config/deepseek-ocr/config.toml`                     | `~/.cache/deepseek-ocr/models/<id>/model.safetensors`         |
+| macOS   | `~/Library/Application Support/deepseek-ocr/config.toml` | `~/Library/Caches/deepseek-ocr/models/<id>/model.safetensors` |
+| Windows | `%APPDATA%\deepseek-ocr\config.toml`                     | `%LOCALAPPDATA%\deepseek-ocr\models\<id>\model.safetensors`   |
 
 - 通过 `--config /path/to/config.toml` 可切换或初始化自定义路径；若文件不存在会自动填入默认值。
 - 参数生效顺序为：命令行参数 → `config.toml` → 内置默认值。资产路径同样遵循该顺序：显式的 `--weights`/`--tokenizer` 会覆盖配置文件，若都未指定则使用上表所列缓存目录。

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -12,36 +12,37 @@ cargo run -p deepseek-ocr-server --release -- \
 
 ## Arguments
 
-| Flag | Default | Description |
-| --- | --- | --- |
-| `--tokenizer PATH` | assets default | Override tokenizer path; otherwise downloaded automatically. |
-| `--weights PATH` | auto-detected | Alternate safetensor checkpoint for the model. |
-| `--device` | `cpu` | Backend for inference: `cpu`, `metal`, or `cuda` (preview). |
-| `--dtype` | backend default | Numeric precision override (`f32`, `f16`, `bf16`, …). |
-| `--base-size` | `1024` | Global canvas resolution for the vision stack. |
-| `--image-size` | `640` | Local crop size when dynamic tiling is enabled. |
-| `--crop-mode` | `true` | Enables dynamic crop mode (`false` to disable). |
-| `--max-new-tokens` | `512` | Default decoding budget applied to incoming requests. |
-| `--host` | `0.0.0.0` | Address Rocket binds to. |
-| `--do-sample` | `false` | Enable sampling for all requests unless overridden per-call. |
-| `--temperature` | `0.0` | Sampling temperature; must be >0 alongside `--do-sample`. |
-| `--top-p` | `1.0` | Nucleus sampling mass (fraction of probability kept). |
-| `--top-k` | – | Top-k cutoff applied during sampling. |
-| `--repetition-penalty` | `1.0` | Token repetition penalty (>1 discourages repeats). |
-| `--no-repeat-ngram-size` | `20` | N-gram blocking window enforced during decoding. |
-| `--seed` | – | RNG seed for sampling (mainly for debugging). |
-| `--port` | `8000` | TCP port for the HTTP server. |
-| `--model-id` | `deepseek-ocr` | Model name returned by `/v1/models` and streamed responses. |
+| Flag                     | Default         | Description                                                                                                                                                 |
+|--------------------------|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--model-config PATH`    | auto-detected   | Specify the model architecture configuration file, overriding the default config.json. In offline environments, point to a pre-downloaded config file path. |
+| `--tokenizer PATH`       | assets default  | Override tokenizer path; otherwise downloaded automatically.                                                                                                |
+| `--weights PATH`         | auto-detected   | Alternate safetensor checkpoint for the model.                                                                                                              |
+| `--device`               | `cpu`           | Backend for inference: `cpu`, `metal`, or `cuda` (preview).                                                                                                 |
+| `--dtype`                | backend default | Numeric precision override (`f32`, `f16`, `bf16`, …).                                                                                                       |
+| `--base-size`            | `1024`          | Global canvas resolution for the vision stack.                                                                                                              |
+| `--image-size`           | `640`           | Local crop size when dynamic tiling is enabled.                                                                                                             |
+| `--crop-mode`            | `true`          | Enables dynamic crop mode (`false` to disable).                                                                                                             |
+| `--max-new-tokens`       | `512`           | Default decoding budget applied to incoming requests.                                                                                                       |
+| `--host`                 | `0.0.0.0`       | Address Rocket binds to.                                                                                                                                    |
+| `--do-sample`            | `false`         | Enable sampling for all requests unless overridden per-call.                                                                                                |
+| `--temperature`          | `0.0`           | Sampling temperature; must be >0 alongside `--do-sample`.                                                                                                   |
+| `--top-p`                | `1.0`           | Nucleus sampling mass (fraction of probability kept).                                                                                                       |
+| `--top-k`                | –               | Top-k cutoff applied during sampling.                                                                                                                       |
+| `--repetition-penalty`   | `1.0`           | Token repetition penalty (>1 discourages repeats).                                                                                                          |
+| `--no-repeat-ngram-size` | `20`            | N-gram blocking window enforced during decoding.                                                                                                            |
+| `--seed`                 | –               | RNG seed for sampling (mainly for debugging).                                                                                                               |
+| `--port`                 | `8000`          | TCP port for the HTTP server.                                                                                                                               |
+| `--model-id`             | `deepseek-ocr`  | Model name returned by `/v1/models` and streamed responses.                                                                                                 |
 
 > **Truncation reminder:** If client responses appear cut off, raise `--max-new-tokens` (or the per-request `max_tokens` body field). The server stops generation once the configured budget is consumed.
 
 ## Configuration & Overrides
 
-| Platform | Config path | Weights cache path |
-| --- | --- | --- |
-| Linux | `~/.config/deepseek-ocr/config.toml` | `~/.cache/deepseek-ocr/models/<id>/model.safetensors` |
-| macOS | `~/Library/Application Support/deepseek-ocr/config.toml` | `~/Library/Caches/deepseek-ocr/models/<id>/model.safetensors` |
-| Windows | `%APPDATA%\deepseek-ocr\config.toml` | `%LOCALAPPDATA%\deepseek-ocr\models\<id>\model.safetensors` |
+| Platform | Config path                                              | Weights cache path                                            |
+|----------|----------------------------------------------------------|---------------------------------------------------------------|
+| Linux    | `~/.config/deepseek-ocr/config.toml`                     | `~/.cache/deepseek-ocr/models/<id>/model.safetensors`         |
+| macOS    | `~/Library/Application Support/deepseek-ocr/config.toml` | `~/Library/Caches/deepseek-ocr/models/<id>/model.safetensors` |
+| Windows  | `%APPDATA%\deepseek-ocr\config.toml`                     | `%LOCALAPPDATA%\deepseek-ocr\models\<id>\model.safetensors`   |
 
 - Use `--config /path/to/config.toml` to load or bootstrap a custom file. Missing files are generated with defaults.
 - Effective values resolve in this order: CLI/server flags → entries in `config.toml` → baked-in defaults. For per-request behaviour the JSON payload wins last (for example `max_tokens` overrides both the CLI flag and config setting). Asset paths behave the same way; explicit flags beat config entries which beat the auto-managed cache paths listed above.

--- a/crates/server/README_CN.md
+++ b/crates/server/README_CN.md
@@ -12,36 +12,37 @@ cargo run -p deepseek-ocr-server --release -- \
 
 ## 参数
 
-| 参数 | 默认值 | 说明 |
-| --- | --- | --- |
-| `--tokenizer PATH` | 资产默认路径 | 指定自定义分词器路径，默认会自动下载。 |
-| `--weights PATH` | 自动探测 | 指定替代模型权重的 safetensor 文件。 |
-| `--device` | `cpu` | 推理后端：`cpu`、`metal` 或 `cuda`（预览）。 |
-| `--dtype` | 依后端而定 | 精度覆盖，如 `f32`、`f16`、`bf16`。 |
-| `--base-size` | `1024` | 传入视觉模块的全局视图分辨率。 |
-| `--image-size` | `640` | 启用动态裁剪时的局部分辨率。 |
-| `--crop-mode` | `true` | 是否启用动态裁剪（`false` 可关闭）。 |
-| `--max-new-tokens` | `512` | 服务端默认的解码上限，可被请求体中的 `max_tokens` 覆盖。 |
-| `--host` | `0.0.0.0` | Rocket 绑定的地址。 |
-| `--do-sample` | `false` | 是否默认启用采样（请求体可再次覆写）。 |
-| `--temperature` | `0.0` | 采样温度，需要与 `--do-sample` 配合且 >0 才生效。 |
-| `--top-p` | `1.0` | 核心采样累计概率，仅在采样时生效。 |
-| `--top-k` | – | Top-k 截断，同样仅在采样时使用。 |
-| `--repetition-penalty` | `1.0` | 重复惩罚系数（>1 会降低重复概率）。 |
-| `--no-repeat-ngram-size` | `20` | 全局 n-gram 阻断窗口。 |
-| `--seed` | – | 采样随机种子，主要用于调试复现。 |
-| `--port` | `8000` | HTTP 监听端口。 |
-| `--model-id` | `deepseek-ocr` | `/v1/models` 以及流式响应中返回的模型名。 |
+| 参数                       | 默认值            | 说明                                           |
+|--------------------------|----------------|----------------------------------------------|
+| `--model-config PATH`    | 自动探测           | 指定模型架构配置文件，覆盖默认的 config.json。离线环境可配置下载好的配置路径 |
+| `--tokenizer PATH`       | 资产默认路径         | 指定自定义分词器路径，默认会自动下载。                          |
+| `--weights PATH`         | 自动探测           | 指定替代模型权重的 safetensor 文件。                     |
+| `--device`               | `cpu`          | 推理后端：`cpu`、`metal` 或 `cuda`（预览）。             |
+| `--dtype`                | 依后端而定          | 精度覆盖，如 `f32`、`f16`、`bf16`。                   |
+| `--base-size`            | `1024`         | 传入视觉模块的全局视图分辨率。                              |
+| `--image-size`           | `640`          | 启用动态裁剪时的局部分辨率。                               |
+| `--crop-mode`            | `true`         | 是否启用动态裁剪（`false` 可关闭）。                       |
+| `--max-new-tokens`       | `512`          | 服务端默认的解码上限，可被请求体中的 `max_tokens` 覆盖。          |
+| `--host`                 | `0.0.0.0`      | Rocket 绑定的地址。                                |
+| `--do-sample`            | `false`        | 是否默认启用采样（请求体可再次覆写）。                          |
+| `--temperature`          | `0.0`          | 采样温度，需要与 `--do-sample` 配合且 >0 才生效。           |
+| `--top-p`                | `1.0`          | 核心采样累计概率，仅在采样时生效。                            |
+| `--top-k`                | –              | Top-k 截断，同样仅在采样时使用。                          |
+| `--repetition-penalty`   | `1.0`          | 重复惩罚系数（>1 会降低重复概率）。                          |
+| `--no-repeat-ngram-size` | `20`           | 全局 n-gram 阻断窗口。                              |
+| `--seed`                 | –              | 采样随机种子，主要用于调试复现。                             |
+| `--port`                 | `8000`         | HTTP 监听端口。                                   |
+| `--model-id`             | `deepseek-ocr` | `/v1/models` 以及流式响应中返回的模型名。                  |
 
 > **截断提示：** 如果客户端响应过早结束，请调大 `--max-new-tokens`（或请求体 `max_tokens`）。只要达到该上限，模型就会停止生成。
 
 ## 配置与覆盖
 
-| 平台 | 配置文件路径 | 权重缓存路径 |
-| --- | --- | --- |
-| Linux | `~/.config/deepseek-ocr/config.toml` | `~/.cache/deepseek-ocr/models/<id>/model.safetensors` |
-| macOS | `~/Library/Application Support/deepseek-ocr/config.toml` | `~/Library/Caches/deepseek-ocr/models/<id>/model.safetensors` |
-| Windows | `%APPDATA%\deepseek-ocr/config.toml` | `%LOCALAPPDATA%\deepseek-ocr\models\<id>\model.safetensors` |
+| 平台      | 配置文件路径                                                   | 权重缓存路径                                                        |
+|---------|----------------------------------------------------------|---------------------------------------------------------------|
+| Linux   | `~/.config/deepseek-ocr/config.toml`                     | `~/.cache/deepseek-ocr/models/<id>/model.safetensors`         |
+| macOS   | `~/Library/Application Support/deepseek-ocr/config.toml` | `~/Library/Caches/deepseek-ocr/models/<id>/model.safetensors` |
+| Windows | `%APPDATA%\deepseek-ocr/config.toml`                     | `%LOCALAPPDATA%\deepseek-ocr\models\<id>\model.safetensors`   |
 
 - 通过 `--config /path/to/config.toml` 可加载或初始化自定义路径，若文件不存在会写入默认内容。
 - 生效顺序为：命令行参数 → `config.toml` → 内置默认值；HTTP 请求体中的字段（如 `max_tokens`）会在该次请求内再次覆盖。资产路径同样遵循此顺序：显式参数 > 配置文件 > 上表所示缓存目录。


### PR DESCRIPTION
When running deepseek-ocr-server in an air-gapped container environment (without external network access), I noticed that the official documentation does not mention the `--model-config` option. After reviewing the source code, I found that explicitly specifying `--model-config` with the path to the local model architecture configuration file prevents the application from attempting to download it remotely, which resolved the issue.

This PR adds documentation for the `--model-config` parameter to help users in offline environments.

Example startup command:
```
deepseek-ocr-server \
--model-id=deepseek-ocr \
--weights=/models/deepseek-ocr/model-00001-of-000001.safetensors \
--tokenizer=/models/deepseek-ocr/tokenizer.json \
--model-config=/models/deepseek-ocr/config.json \
--host=0.0.0.0 \
--port=8000 \
--device=cpu \
--max-new-tokens=512
```